### PR TITLE
Fix namespace for SortableLink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/*
+composer.lock

--- a/src/SortableLink.php
+++ b/src/SortableLink.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sortable\Requests;
+namespace Sortable;
 
 use Illuminate\Support\Facades\Request;
 


### PR DESCRIPTION
The namespace for class `SortableLink` is wrong and class `Assessor` fails to use it.
(Is `Assessor` a typo for `Accessor`?)