### PR TITLE
Avoid unnecessary "?" when there are no parameters

### DIFF
--- a/src/SortableLink.php
+++ b/src/SortableLink.php
@@ -38,7 +38,13 @@ class SortableLink
             })
             ->toArray();
 
-        return '?' . implode('&', $queryStringList);
+        if (count($queryStringList) > 0) {
+            $generatedQuery = '?' . implode('&', $queryStringList);
+        } else {
+            $generatedQuery = '';
+        }
+
+        return $generatedQuery;
     }
 
     private function nextSort($baseKey, $sort, $direction)


### PR DESCRIPTION
To avoid unnecessary `?` at the end of the URL when there are no query parameters.
e.g. ) when jump from `localhost/index?sort=name&direction=desc` to `localhost/index?`